### PR TITLE
Add real-time multiplayer math arena scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.DS_Store
+npm-debug.log*
+/dist

--- a/README.md
+++ b/README.md
@@ -1,38 +1,83 @@
-# Test
+# Math Arena
 
-Welcome to the **Test** repository!
+A real-time multiplayer math challenge built with Node.js, Express, Socket.IO, and a mobile-friendly web interface. Players can host or join lobbies, compete to answer math prompts, and track scores on a live leaderboard.
 
-## Description
+## Project Structure
 
-A brief description of your project goes here. Explain the purpose, main features, or goals of the project.
-
-## Getting Started
-
-### Prerequisites
-
-List any prerequisites, libraries, OS version, etc., needed before installing your project.
-
-### Installation
-
-```bash
-# Example installation command
-git clone https://github.com/kevins/Test.git
-cd Test
-# Add installation steps here
+```
+Test/
+├── server/   # Express + Socket.IO backend
+└── client/   # Responsive browser client served with lite-server
 ```
 
-## Usage
+## Features
 
-Provide instructions and examples for using your project.
+- Lobby creation with shareable 5-character room codes
+- Real-time player synchronization and score tracking
+- Adjustable difficulty (easy/medium/hard) controlled by the host
+- Automatic round progression through 10 math prompts
+- Mobile-first UI that works across multiple simultaneous clients
 
-## Contributing
+## Prerequisites
 
-Contributions are welcome! Please open an issue or submit a pull request for any changes.
+- [Node.js](https://nodejs.org/) 18 or newer
+- npm (bundled with Node.js)
+
+## Setup
+
+Install dependencies for both the server and the client:
+
+```bash
+cd server
+npm install
+
+cd ../client
+npm install
+```
+
+> **Note:** The repository does not include `node_modules`. Run `npm install` in each directory on a machine with npm registry access.
+
+## Running the Application
+
+### 1. Start the server
+
+```bash
+cd server
+npm run start
+```
+
+The server listens on port **4000** by default. You can change the port with the `PORT` environment variable.
+
+### 2. Launch the web client
+
+In a new terminal:
+
+```bash
+cd client
+npm run start
+```
+
+The client runs on port **3000** via `lite-server`. It serves static assets and hot-reloads changes during development.
+
+### 3. Connect from devices
+
+- On desktop: open [http://localhost:3000](http://localhost:3000).
+- On mobile devices connected to the same network, use the host machine's LAN IP. For example: `http://192.168.1.50:3000/?server=http://192.168.1.50:4000`.
+  - The `server` query parameter allows pointing the client to the correct Socket.IO endpoint when not running on localhost.
+
+## Gameplay Flow
+
+1. A player hosts a lobby from the "Host a Lobby" form and shares the generated room code.
+2. Other players join using the room code from the "Join a Lobby" form.
+3. Once everyone is ready, the host starts the game. Math prompts appear simultaneously for all players.
+4. Players submit answers from their devices. Correct answers earn 10 points.
+5. After each round, the leaderboard updates. After 10 rounds, final results are displayed.
+
+## Additional Configuration
+
+- **Round Limit:** Override the default 10 rounds by exporting `ROUND_LIMIT` when starting the server (e.g., `ROUND_LIMIT=5 npm run start`).
+- **CORS:** Socket.IO is configured to accept connections from any origin for easier local development. Adjust in `server/src/server.js` for production.
 
 ## License
 
-This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
-
-## Contact
-
-For questions or suggestions, please contact [kevins](https://github.com/kevins).
+This project is released under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/client/app.js
+++ b/client/app.js
@@ -1,0 +1,249 @@
+const serverUrl = (() => {
+  if (typeof window === 'undefined') return '';
+  const params = new URLSearchParams(window.location.search);
+  const override = params.get('server');
+  if (override) return override;
+  if (window.location.hostname === 'localhost') {
+    return 'http://localhost:4000';
+  }
+  return `${window.location.protocol}//${window.location.hostname}:4000`;
+})();
+
+const socket = io(serverUrl, {
+  transports: ['websocket'],
+  autoConnect: true
+});
+
+const state = {
+  code: null,
+  isHost: false,
+  inGame: false,
+  difficulty: 'easy'
+};
+
+const panels = {
+  auth: document.getElementById('auth-panel'),
+  lobby: document.getElementById('lobby-panel'),
+  game: document.getElementById('game-panel'),
+  results: document.getElementById('results-panel')
+};
+
+const lobbyCodeLabel = document.getElementById('lobby-code');
+const playerList = document.getElementById('player-list');
+const lobbyInfo = document.getElementById('lobby-info');
+const difficultyControl = document.getElementById('difficulty-control');
+const lobbyDifficultySelect = document.getElementById('lobby-difficulty');
+const startButton = document.getElementById('start-game');
+const questionText = document.getElementById('question-text');
+const roundNumber = document.getElementById('round-number');
+const roundMeta = document.getElementById('round-meta');
+const leaderboardList = document.getElementById('leaderboard-list');
+const answerForm = document.getElementById('answer-form');
+const answerInput = document.getElementById('answer-input');
+const answerFeedback = document.getElementById('answer-feedback');
+const resultsList = document.getElementById('results-list');
+
+const createForm = document.getElementById('create-form');
+const hostNameInput = document.getElementById('host-name');
+const difficultySelect = document.getElementById('difficulty');
+
+const joinForm = document.getElementById('join-form');
+const joinNameInput = document.getElementById('join-name');
+const roomCodeInput = document.getElementById('room-code');
+
+const leaveButton = document.getElementById('leave-game');
+const playAgainButton = document.getElementById('play-again');
+
+function showPanel(key) {
+  Object.entries(panels).forEach(([panelKey, el]) => {
+    if (panelKey === key) {
+      el.classList.remove('hidden');
+    } else {
+      el.classList.add('hidden');
+    }
+  });
+}
+
+function renderPlayers(players = []) {
+  playerList.innerHTML = '';
+  players.forEach((player) => {
+    const li = document.createElement('li');
+    li.textContent = `${player.name} — ${player.score} pts`;
+    if (player.id === socket.id) {
+      const you = document.createElement('span');
+      you.textContent = ' (You)';
+      li.appendChild(you);
+    }
+    playerList.appendChild(li);
+  });
+}
+
+function renderLeaderboard(players = []) {
+  leaderboardList.innerHTML = '';
+  players.forEach((player) => {
+    const li = document.createElement('li');
+    const name = document.createElement('span');
+    name.textContent = player.name;
+    const score = document.createElement('span');
+    score.textContent = `${player.score} pts`;
+    li.appendChild(name);
+    li.appendChild(score);
+    leaderboardList.appendChild(li);
+  });
+}
+
+function renderResults(players = []) {
+  resultsList.innerHTML = '';
+  players.forEach((player, index) => {
+    const li = document.createElement('li');
+    li.innerHTML = `<span>#${index + 1} ${player.name}</span><span>${player.score} pts</span>`;
+    resultsList.appendChild(li);
+  });
+}
+
+function updateLobbyInfo({ round }) {
+  const hostLabel = state.isHost ? 'You are the host.' : 'Waiting for host actions…';
+  lobbyInfo.textContent = `${hostLabel} Difficulty: ${state.difficulty}. Current round: ${round || 0}.`;
+  startButton.style.display = state.isHost ? 'inline-flex' : 'none';
+  if (state.isHost) {
+    difficultyControl.classList.remove('hidden');
+    lobbyDifficultySelect.value = state.difficulty;
+  } else {
+    difficultyControl.classList.add('hidden');
+  }
+}
+
+function resetGameUI() {
+  state.inGame = false;
+  questionText.textContent = 'Waiting for the host to start…';
+  answerForm.reset();
+  answerInput.disabled = true;
+  answerFeedback.textContent = '';
+  leaderboardList.innerHTML = '';
+}
+
+createForm.addEventListener('submit', (event) => {
+  event.preventDefault();
+  const name = hostNameInput.value.trim();
+  if (!name) return;
+  socket.emit('createLobby', {
+    name,
+    difficulty: difficultySelect.value
+  });
+});
+
+joinForm.addEventListener('submit', (event) => {
+  event.preventDefault();
+  const name = joinNameInput.value.trim();
+  const code = roomCodeInput.value.trim();
+  if (!name || !code) return;
+  socket.emit('joinLobby', {
+    name,
+    code
+  });
+});
+
+startButton.addEventListener('click', () => {
+  if (!state.isHost || !state.code) return;
+  socket.emit('startGame', { code: state.code });
+});
+
+leaveButton.addEventListener('click', () => {
+  window.location.reload();
+});
+
+playAgainButton.addEventListener('click', () => {
+  window.location.reload();
+});
+
+answerForm.addEventListener('submit', (event) => {
+  event.preventDefault();
+  if (!state.code) return;
+  const answer = answerInput.value;
+  socket.emit('submitAnswer', { code: state.code, answer });
+  answerInput.disabled = true;
+});
+
+socket.on('connect', () => {
+  console.log('Connected to server');
+});
+
+socket.on('disconnect', () => {
+  alert('Disconnected from server. Please refresh.');
+});
+
+socket.on('lobbyCreated', ({ code, host }) => {
+  state.code = code;
+  state.isHost = host;
+  state.difficulty = difficultySelect.value;
+  lobbyCodeLabel.textContent = code;
+  showPanel('lobby');
+  updateLobbyInfo({ round: 0 });
+});
+
+socket.on('lobbyJoined', ({ code, host }) => {
+  state.code = code;
+  state.isHost = host;
+  lobbyCodeLabel.textContent = code;
+  showPanel('lobby');
+  updateLobbyInfo({ round: 0 });
+});
+
+socket.on('lobbyUpdate', ({ code, players, round, difficulty }) => {
+  if (code !== state.code) return;
+  if (difficulty) {
+    state.difficulty = difficulty;
+    lobbyDifficultySelect.value = difficulty;
+  }
+  renderPlayers(players);
+  renderLeaderboard(players.sort((a, b) => b.score - a.score));
+  updateLobbyInfo({ round });
+});
+
+socket.on('hostPromotion', () => {
+  state.isHost = true;
+  updateLobbyInfo({ round: 0 });
+});
+
+lobbyDifficultySelect.addEventListener('change', (event) => {
+  if (!state.isHost || !state.code) {
+    event.target.value = state.difficulty;
+    return;
+  }
+  state.difficulty = event.target.value;
+  socket.emit('setDifficulty', { code: state.code, difficulty: state.difficulty });
+});
+
+socket.on('newQuestion', ({ prompt, round, remainingRounds }) => {
+  state.inGame = true;
+  showPanel('game');
+  roundNumber.textContent = round;
+  roundMeta.textContent = `${remainingRounds} rounds remaining`;
+  questionText.textContent = prompt;
+  answerInput.disabled = false;
+  answerInput.value = '';
+  answerInput.focus();
+  answerFeedback.textContent = '';
+});
+
+socket.on('answerResult', ({ correct, correctAnswer }) => {
+  answerFeedback.textContent = correct
+    ? 'Correct! +10 pts'
+    : `Not quite. Correct answer: ${correctAnswer}`;
+});
+
+socket.on('roundResults', ({ players, correctAnswer }) => {
+  renderLeaderboard(players);
+  answerFeedback.textContent = `Round complete. Correct answer: ${correctAnswer}`;
+});
+
+socket.on('gameOver', ({ players }) => {
+  renderResults(players);
+  showPanel('results');
+});
+
+socket.on('errorMessage', (message) => {
+  alert(message);
+});
+
+resetGameUI();

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Math Arena</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="app">
+      <section class="panel" id="auth-panel">
+        <h1>Math Arena</h1>
+        <p class="tagline">Create a lobby or join with a room code to play.</p>
+        <form id="create-form" class="card">
+          <h2>Host a Lobby</h2>
+          <label class="field">
+            <span>Your Name</span>
+            <input type="text" id="host-name" required placeholder="Alex" />
+          </label>
+          <label class="field">
+            <span>Difficulty</span>
+            <select id="difficulty">
+              <option value="easy">Easy</option>
+              <option value="medium">Medium</option>
+              <option value="hard">Hard</option>
+            </select>
+          </label>
+          <button type="submit" class="primary">Create Lobby</button>
+        </form>
+
+        <form id="join-form" class="card">
+          <h2>Join a Lobby</h2>
+          <label class="field">
+            <span>Your Name</span>
+            <input type="text" id="join-name" required placeholder="Sky" />
+          </label>
+          <label class="field">
+            <span>Room Code</span>
+            <input type="text" id="room-code" maxlength="5" required placeholder="ABCDE" />
+          </label>
+          <button type="submit" class="secondary">Join Lobby</button>
+        </form>
+      </section>
+
+      <section class="panel hidden" id="lobby-panel">
+        <header class="panel-header">
+          <div>
+            <h2>Lobby <span id="lobby-code"></span></h2>
+            <p>Share the code with friends to join from their phones.</p>
+          </div>
+          <button id="start-game" class="primary">Start Game</button>
+        </header>
+        <div class="card">
+          <h3>Players</h3>
+          <ul id="player-list"></ul>
+        </div>
+        <div class="card info">
+          <div id="lobby-info"></div>
+          <label class="field inline hidden" id="difficulty-control">
+            <span>Adjust difficulty</span>
+            <select id="lobby-difficulty">
+              <option value="easy">Easy</option>
+              <option value="medium">Medium</option>
+              <option value="hard">Hard</option>
+            </select>
+          </label>
+        </div>
+      </section>
+
+      <section class="panel hidden" id="game-panel">
+        <header class="panel-header">
+          <div>
+            <h2>Round <span id="round-number">1</span></h2>
+            <p id="round-meta"></p>
+          </div>
+          <button id="leave-game" class="secondary">Leave</button>
+        </header>
+
+        <div class="card prompt">
+          <p class="prompt-text" id="question-text">Waiting for the host to start…</p>
+        </div>
+
+        <form id="answer-form" class="card answer-form">
+          <label class="field">
+            <span>Your Answer</span>
+            <input type="number" id="answer-input" inputmode="numeric" required />
+          </label>
+          <button type="submit" class="primary">Submit</button>
+          <p class="feedback" id="answer-feedback"></p>
+        </form>
+
+        <div class="card leaderboard">
+          <h3>Leaderboard</h3>
+          <ol id="leaderboard-list"></ol>
+        </div>
+      </section>
+
+      <section class="panel hidden" id="results-panel">
+        <header class="panel-header">
+          <div>
+            <h2>Final Results</h2>
+            <p>Great job! Share the standings below.</p>
+          </div>
+          <button id="play-again" class="primary">Play Again</button>
+        </header>
+        <div class="card leaderboard">
+          <ol id="results-list"></ol>
+        </div>
+      </section>
+    </main>
+
+    <script src="https://cdn.socket.io/4.7.5/socket.io.min.js" integrity="sha384-xPj3TDIrS9KuX3sI5OGucs5cjox96D65gis6pZeRAEIJ5zsxFrqxbPjzvY4xXHzd" crossorigin="anonymous"></script>
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "math-arena-client",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Responsive multiplayer math game UI",
+  "scripts": {
+    "start": "lite-server"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "socket.io-client": "^4.7.5"
+  },
+  "devDependencies": {
+    "lite-server": "^2.6.1"
+  }
+}

--- a/client/styles.css
+++ b/client/styles.css
@@ -1,0 +1,179 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: radial-gradient(circle at top, #23395d, #101725 55%);
+  color: #f4f6fb;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+}
+
+h1,
+ h2,
+ h3 {
+  margin: 0;
+}
+
+.app {
+  width: min(900px, 100%);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.panel {
+  background: rgba(15, 20, 35, 0.72);
+  border-radius: 16px;
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.35);
+}
+
+.hidden {
+  display: none !important;
+}
+
+.tagline {
+  color: #bfc6dd;
+}
+
+.card {
+  background: rgba(10, 14, 25, 0.85);
+  border-radius: 12px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.card.info {
+  color: #bfc6dd;
+  font-size: 0.95rem;
+}
+
+.panel-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+}
+
+.field.inline {
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.field.inline span {
+  font-weight: 600;
+}
+
+.field.inline select {
+  max-width: 150px;
+}
+
+.field input,
+.field select {
+  padding: 0.65rem 0.8rem;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+}
+
+.primary,
+.secondary {
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.6rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primary {
+  background: linear-gradient(135deg, #6dd5ff, #2196f3);
+  color: #06172a;
+}
+
+.secondary {
+  background: rgba(255, 255, 255, 0.1);
+  color: #f3f6ff;
+}
+
+.primary:hover,
+.secondary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 25px rgba(0, 0, 0, 0.25);
+}
+
+ul,
+ol {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.leaderboard li,
+.leaderboard ol li {
+  display: flex;
+  justify-content: space-between;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 8px;
+  padding: 0.65rem 0.8rem;
+}
+
+.prompt {
+  text-align: center;
+  font-size: 2.5rem;
+  font-weight: 700;
+}
+
+.prompt-text {
+  margin: 0;
+}
+
+.answer-form {
+  gap: 0.5rem;
+}
+
+.feedback {
+  min-height: 1.25rem;
+  color: #fdd835;
+  font-weight: 600;
+}
+
+@media (max-width: 640px) {
+  body {
+    padding: 1rem 0.5rem;
+  }
+
+  .panel {
+    padding: 1.25rem;
+  }
+
+  .prompt {
+    font-size: 2rem;
+  }
+}

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "math-arena-server",
+  "version": "1.0.0",
+  "description": "Real-time math lobby server with Socket.IO",
+  "type": "commonjs",
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js",
+    "dev": "NODE_ENV=development node src/server.js"
+  },
+  "keywords": [
+    "socket.io",
+    "express",
+    "math",
+    "multiplayer"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
+    "socket.io": "^4.7.5"
+  }
+}

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -1,0 +1,283 @@
+const express = require('express');
+const http = require('http');
+const { Server } = require('socket.io');
+const cors = require('cors');
+
+const PORT = process.env.PORT || 4000;
+const ROUND_LIMIT = parseInt(process.env.ROUND_LIMIT || '10', 10);
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+app.get('/health', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+const server = http.createServer(app);
+const io = new Server(server, {
+  cors: {
+    origin: '*',
+    methods: ['GET', 'POST']
+  }
+});
+
+const lobbies = new Map();
+
+function generateLobbyCode() {
+  const chars = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';
+  let code;
+  do {
+    code = Array.from({ length: 5 }, () => chars[Math.floor(Math.random() * chars.length)]).join('');
+  } while (lobbies.has(code));
+  return code;
+}
+
+function generateQuestion(difficulty = 'easy') {
+  const operations = ['+', '-', '*'];
+  const op = operations[Math.floor(Math.random() * operations.length)];
+  let a;
+  let b;
+
+  switch (difficulty) {
+    case 'medium':
+      a = Math.floor(Math.random() * 50) + 10;
+      b = Math.floor(Math.random() * 50) + 10;
+      break;
+    case 'hard':
+      a = Math.floor(Math.random() * 90) + 10;
+      b = Math.floor(Math.random() * 90) + 10;
+      break;
+    case 'easy':
+    default:
+      a = Math.floor(Math.random() * 10) + 1;
+      b = Math.floor(Math.random() * 10) + 1;
+      break;
+  }
+
+  let answer;
+  switch (op) {
+    case '+':
+      answer = a + b;
+      break;
+    case '-':
+      answer = a - b;
+      break;
+    case '*':
+      answer = a * b;
+      break;
+  }
+
+  return {
+    prompt: `${a} ${op} ${b}`,
+    answer
+  };
+}
+
+function createLobby(hostSocket, hostName) {
+  const code = generateLobbyCode();
+  const lobby = {
+    code,
+    hostId: hostSocket.id,
+    players: new Map(),
+    round: 0,
+    answers: new Map(),
+    difficulty: 'easy'
+  };
+
+  lobby.players.set(hostSocket.id, {
+    id: hostSocket.id,
+    name: hostName,
+    score: 0
+  });
+
+  lobbies.set(code, lobby);
+  hostSocket.join(code);
+  return lobby;
+}
+
+function emitLobbyState(lobby) {
+  io.to(lobby.code).emit('lobbyUpdate', {
+    code: lobby.code,
+    round: lobby.round,
+    difficulty: lobby.difficulty,
+    players: Array.from(lobby.players.values())
+  });
+}
+
+function broadcastQuestion(lobby) {
+  const { prompt } = lobby.currentQuestion;
+  io.to(lobby.code).emit('newQuestion', {
+    prompt,
+    round: lobby.round,
+    remainingRounds: ROUND_LIMIT - lobby.round
+  });
+}
+
+function startNextRound(lobby) {
+  if (lobby.round >= ROUND_LIMIT) {
+    io.to(lobby.code).emit('gameOver', {
+      players: Array.from(lobby.players.values()).sort((a, b) => b.score - a.score)
+    });
+    return;
+  }
+
+  lobby.round += 1;
+  lobby.answers.clear();
+  lobby.currentQuestion = generateQuestion(lobby.difficulty);
+  emitLobbyState(lobby);
+  broadcastQuestion(lobby);
+}
+
+io.on('connection', (socket) => {
+  socket.on('createLobby', ({ name, difficulty }) => {
+    if (!name) {
+      socket.emit('errorMessage', 'Name is required');
+      return;
+    }
+
+    const lobby = createLobby(socket, name.trim());
+    if (difficulty) {
+      lobby.difficulty = difficulty;
+    }
+
+    emitLobbyState(lobby);
+    socket.emit('lobbyCreated', { code: lobby.code, host: true });
+  });
+
+  socket.on('joinLobby', ({ code, name }) => {
+    const normalizedCode = (code || '').toUpperCase();
+    const lobby = lobbies.get(normalizedCode);
+
+    if (!lobby) {
+      socket.emit('errorMessage', 'Lobby not found');
+      return;
+    }
+
+    if (!name) {
+      socket.emit('errorMessage', 'Name is required');
+      return;
+    }
+
+    lobby.players.set(socket.id, {
+      id: socket.id,
+      name: name.trim(),
+      score: 0
+    });
+
+    socket.join(lobby.code);
+    emitLobbyState(lobby);
+    socket.emit('lobbyJoined', { code: lobby.code, host: lobby.hostId === socket.id });
+  });
+
+  socket.on('startGame', ({ code }) => {
+    const lobby = lobbies.get((code || '').toUpperCase());
+    if (!lobby) {
+      socket.emit('errorMessage', 'Lobby not found');
+      return;
+    }
+
+    if (socket.id !== lobby.hostId) {
+      socket.emit('errorMessage', 'Only the host can start the game');
+      return;
+    }
+
+    startNextRound(lobby);
+  });
+
+  socket.on('submitAnswer', ({ code, answer }) => {
+    const lobby = lobbies.get((code || '').toUpperCase());
+    if (!lobby) {
+      socket.emit('errorMessage', 'Lobby not found');
+      return;
+    }
+
+    if (!lobby.players.has(socket.id)) {
+      socket.emit('errorMessage', 'You are not part of this lobby');
+      return;
+    }
+
+    if (!lobby.currentQuestion) {
+      socket.emit('errorMessage', 'No active question');
+      return;
+    }
+
+    if (lobby.answers.has(socket.id)) {
+      socket.emit('errorMessage', 'Answer already submitted for this round');
+      return;
+    }
+
+    const numericAnswer = Number(answer);
+    const isCorrect = Number.isFinite(numericAnswer) && numericAnswer === lobby.currentQuestion.answer;
+
+    if (isCorrect) {
+      const player = lobby.players.get(socket.id);
+      player.score += 10;
+    }
+
+    lobby.answers.set(socket.id, {
+      id: socket.id,
+      answer: numericAnswer,
+      correct: isCorrect
+    });
+
+    socket.emit('answerResult', {
+      correct: isCorrect,
+      correctAnswer: lobby.currentQuestion.answer
+    });
+
+    if (lobby.answers.size === lobby.players.size) {
+      io.to(lobby.code).emit('roundResults', {
+        round: lobby.round,
+        correctAnswer: lobby.currentQuestion.answer,
+        players: Array.from(lobby.players.values()).sort((a, b) => b.score - a.score)
+      });
+
+      setTimeout(() => startNextRound(lobby), 2000);
+    }
+  });
+
+  socket.on('setDifficulty', ({ code, difficulty }) => {
+    const lobby = lobbies.get((code || '').toUpperCase());
+    if (!lobby) {
+      socket.emit('errorMessage', 'Lobby not found');
+      return;
+    }
+
+    if (socket.id !== lobby.hostId) {
+      socket.emit('errorMessage', 'Only the host can change difficulty');
+      return;
+    }
+
+    lobby.difficulty = difficulty || 'easy';
+    emitLobbyState(lobby);
+  });
+
+  socket.on('disconnect', () => {
+    lobbies.forEach((lobby, code) => {
+      if (lobby.players.has(socket.id)) {
+        lobby.players.delete(socket.id);
+        lobby.answers.delete(socket.id);
+
+        if (lobby.hostId === socket.id) {
+          const [nextHostId] = lobby.players.keys();
+          lobby.hostId = nextHostId;
+          if (nextHostId) {
+            io.to(nextHostId).emit('hostPromotion', true);
+          }
+        }
+
+        if (lobby.players.size === 0) {
+          lobbies.delete(code);
+        } else {
+          emitLobbyState(lobby);
+        }
+      }
+    });
+  });
+});
+
+server.listen(PORT, () => {
+  // eslint-disable-next-line no-console
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- scaffold an Express + Socket.IO backend that manages lobbies, question rounds, scoring, and difficulty updates
- build a responsive Socket.IO-powered client for hosting, joining, and playing math rounds across devices
- document setup/run steps and add repository ignores for node modules

## Testing
- Not run (npm registry access is restricted in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e47618e39083339b2598ecbe997d8c